### PR TITLE
Special fix for DateTime serialization.

### DIFF
--- a/src/Zumba/Util/JsonSerializer.php
+++ b/src/Zumba/Util/JsonSerializer.php
@@ -182,6 +182,13 @@ class JsonSerializer {
 		if (!class_exists($className)) {
 			throw new JsonSerializerException('Unable to find class ' . $className);
 		}
+
+		if ($className === 'DateTime') {
+			$obj = $this->restoreUsingUnserialize($className, $value);
+			$this->objectMapping[$this->objectMappingIndex++] = $obj;
+			return $obj;
+		}
+
 		$ref = new ReflectionClass($className);
 		$obj = version_compare(PHP_VERSION, '5.4.0') >= 0 ?
 			$ref->newInstanceWithoutConstructor() :
@@ -200,6 +207,12 @@ class JsonSerializer {
 			$obj->__wakeup();
 		}
 		return $obj;
+	}
+
+	protected function restoreUsingUnserialize($className, $attributes) {
+		$obj = (object)$attributes;
+		$serialized = preg_replace('|^O:\d+:"\w+":|', 'O:' . strlen($className) . ':"' . $className . '":', serialize($obj));
+		return unserialize($serialized);
 	}
 
 	/**

--- a/tests/Zumba/Util/Test/JsonSerializerTest.php
+++ b/tests/Zumba/Util/Test/JsonSerializerTest.php
@@ -210,6 +210,20 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test serialization of DateTime classes
+	 *
+	 * Some interal classes, such as DateTime, cannot be initialized with
+	 * ReflectionClass::newInstanceWithoutConstructor()
+	 *
+	 * @return void
+	 */
+	public function testSerializationOfDateTime() {
+		$date = new \DateTime('2014-06-15 12:00:00', new \DateTimeZone('UTC'));
+		$obj = $this->serializer->unserialize($this->serializer->serialize($date));
+		$this->assertSame($date->getTimestamp(), $obj->getTimestamp());
+	}
+
+	/**
 	 * Test unserialize of unknown class
 	 *
 	 * @return void


### PR DESCRIPTION
DateTime cannot use ReflectionClass::newInstanceWithoutConstructor() neither simple unserialize. This is why this special case.

Fixes #2
