### PR TITLE
avoiding notices on undefined properties

### DIFF
--- a/src/Zumba/Util/JsonSerializer.php
+++ b/src/Zumba/Util/JsonSerializer.php
@@ -182,7 +182,9 @@ class JsonSerializer {
 				$propRef->setAccessible(true);
 				$data[$property] = $propRef->getValue($value);
 			} catch (ReflectionException $e) {
-				$data[$property] = $value->$property;
+				if(isset($value->$property)) {
+					$data[$property] = $value->$property;
+				}
 			}
 		}
 		return $data;


### PR DESCRIPTION
If a property does not exist on an object, but __sleep is referencing it, then a notice is thrown. The fix just silently ignores that case.