### PR TITLE
Changed namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Changed
+- Throwing exception if cannot decode JSON when unserializing
+### Deprecated
+- Changed namespace from `Zumba\Util` to `Zumba\JsonSerializer`
+
+## [2.0.1] - 2016-03-17
+### Fixed
+- Fixing float serialization on i18n locales
+
+## [2.0.0] - 2016-02-26
+### Added
+- Support PHP closures serialization
+### Removed
+- Dropped support to PHP 5.3
+### Changed
+- Documentation improvements
+- Support to PHP built-in support to float numbers without decimal points
+- Using PSR-2 and PSR-4
+
+## [1.0.1] - 2014-07-05
+### Added
+- Support to DateTime serialization
+- Support to unescaped unicode
+
+## [1.0.1] - 2014-04-12
+### Fixed
+- Fixed serialization of float numbers without decimal points
+
+## [1.0.0] - 2014-01-06
+### Added
+- Encode/Decode of scalar, null, array
+- Encode/Decode of objects
+- Support nested serialization
+- Support not declared properties on the original class definition (ie, properties in stdClass)
+- Support object recursion

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class MyCustomClass {
 
 $instance = new MyCustomClass();
 
-$serializer = new Zumba\Util\JsonSerializer();
+$serializer = new Zumba\JsonSerializer\JsonSerializer();
 $json = $serializer->serialize($instance);
 // $json will contain the content {"@type":"MyCustomClass","isItAwesome":true,"nice":"very!"}
 
@@ -85,7 +85,7 @@ $toBeSerialized = array(
 );
 
 $superClosure = new SuperClosure\Serializer();
-$jsonSerializer = new Zumba\Util\JsonSerializer($superClosure);
+$jsonSerializer = new Zumba\JsonSerializer\JsonSerializer($superClosure);
 $serialized = $jsonSerializer->serialize($toBeSerialized);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "autoload": {
         "psr-4": {
             "Zumba\\": "src/",
-            "Zumba\\Util\\Test\\": "tests/"
+            "Zumba\\JsonSerializer\\Test\\": "tests/"
         }
     }
 }

--- a/src/Exception/JsonSerializerException.php
+++ b/src/Exception/JsonSerializerException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Zumba\Exception;
+
+use RuntimeException;
+
+/**
+ * @deprecated Will be removed on the 3.0.0. Use Zumba\JsonSerializer\Exception\JsonSerializerException instead
+ */
+class JsonSerializerException extends RuntimeException
+{
+}

--- a/src/JsonSerializer/Exception/JsonSerializerException.php
+++ b/src/JsonSerializer/Exception/JsonSerializerException.php
@@ -2,8 +2,8 @@
 
 namespace Zumba\JsonSerializer\Exception;
 
-use RuntimeException;
+use Zumba\Exception\JsonSerializerException as OriginalException;
 
-class JsonSerializerException extends RuntimeException
+class JsonSerializerException extends OriginalException
 {
 }

--- a/src/JsonSerializer/Exception/JsonSerializerException.php
+++ b/src/JsonSerializer/Exception/JsonSerializerException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zumba\Exception;
+namespace Zumba\JsonSerializer\Exception;
 
 use RuntimeException;
 

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Zumba\Util;
+namespace Zumba\JsonSerializer;
 
 use ReflectionClass;
 use ReflectionException;
 use SplObjectStorage;
-use Zumba\Exception\JsonSerializerException;
+use Zumba\JsonSerializer\Exception\JsonSerializerException;
 use SuperClosure\SerializerInterface as ClosureSerializerInterface;
 
 class JsonSerializer
@@ -68,7 +68,7 @@ class JsonSerializer
      *
      * @param mixed $value
      * @return string JSON encoded
-     * @throws Zumba\Exception\JsonSerializerException
+     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
      */
     public function serialize($value)
     {
@@ -126,7 +126,7 @@ class JsonSerializer
      *
      * @param mixed $value
      * @return mixed
-     * @throws Zumba\Exception\JsonSerializerException
+     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
      */
     protected function serializeData($value)
     {
@@ -251,7 +251,7 @@ class JsonSerializer
      *
      * @param aray $value
      * @return object
-     * @throws Zumba\Exception\JsonSerializerException
+     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
      */
     protected function unserializeObject($value)
     {

--- a/src/Util/JsonSerializer.php
+++ b/src/Util/JsonSerializer.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Zumba\Util;
+
+use Zumba\JsonSerializer\JsonSerializer as NewJsonSerializer;
+
+/**
+ * @deprecated Will be removed on the 3.0.0. Use Zumba\JsonSerializer\JsonSerializer instead
+ */
+class JsonSerializer extends NewJsonSerializer
+{
+}

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -407,12 +407,12 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      * @return void
      * @deprecated
      */
-    public function testNamespaceRename() {
+    public function testNamespaceRename()
+    {
         $serializer = new \Zumba\Util\JsonSerializer();
 
         $f = fopen(__FILE__, 'r');
         $this->setExpectedException('Zumba\Exception\JsonSerializerException');
         $this->serializer->serialize($f);
     }
-
 }

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Zumba\Util\Test;
+namespace Zumba\JsonSerializer\Test;
 
-use Zumba\Util\JsonSerializer;
+use Zumba\JsonSerializer\JsonSerializer;
 use stdClass;
 use SuperClosure\Serializer as ClosureSerializer;
 
@@ -12,7 +12,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
     /**
      * Serializer instance
      *
-     * @var Zumba\Util\JsonSerializer
+     * @var Zumba\JsonSerializer\JsonSerializer
      */
     protected $serializer;
 
@@ -102,7 +102,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializeResource()
     {
-        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->setExpectedException('Zumba\JsonSerializer\Exception\JsonSerializerException');
         $this->serializer->serialize(fopen(__FILE__, 'r'));
     }
 
@@ -113,7 +113,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializeClosureWithoutSerializer()
     {
-        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->setExpectedException('Zumba\JsonSerializer\Exception\JsonSerializerException');
         $this->serializer->serialize(array('func' => function () {
             echo 'whoops';
         }));
@@ -175,22 +175,22 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('{"@type":"stdClass"}', $this->serializer->serialize($obj));
 
         $obj = $empty = new SupportClasses\EmptyClass();
-        $this->assertSame('{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"}', $this->serializer->serialize($obj));
+        $this->assertSame('{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"}', $this->serializer->serialize($obj));
 
         $obj = new SupportClasses\AllVisibilities();
-        $expected = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":"this is public","prot":"protected","priv":"dont tell anyone"}';
+        $expected = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":"this is public","prot":"protected","priv":"dont tell anyone"}';
         $this->assertSame($expected, $this->serializer->serialize($obj));
 
         $obj->pub = 'new value';
-        $expected = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":"new value","prot":"protected","priv":"dont tell anyone"}';
+        $expected = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":"new value","prot":"protected","priv":"dont tell anyone"}';
         $this->assertSame($expected, $this->serializer->serialize($obj));
 
         $obj->pub = $empty;
-        $expected = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"},"prot":"protected","priv":"dont tell anyone"}';
+        $expected = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"},"prot":"protected","priv":"dont tell anyone"}';
         $this->assertSame($expected, $this->serializer->serialize($obj));
 
         $array = array('instance' => $empty);
-        $expected = '{"instance":{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"}}';
+        $expected = '{"instance":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"}}';
         $this->assertSame($expected, $this->serializer->serialize($array));
 
         $obj = new stdClass();
@@ -211,21 +211,21 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
         $obj = $this->serializer->unserialize($serialized);
         $this->assertInstanceOf('stdClass', $obj);
 
-        $serialized = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"}';
+        $serialized = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"}';
         $obj = $this->serializer->unserialize($serialized);
-        $this->assertInstanceOf('Zumba\Util\Test\SupportClasses\EmptyClass', $obj);
+        $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportClasses\EmptyClass', $obj);
 
-        $serialized = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"},"prot":"protected","priv":"dont tell anyone"}';
+        $serialized = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\AllVisibilities","pub":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"},"prot":"protected","priv":"dont tell anyone"}';
         $obj = $this->serializer->unserialize($serialized);
-        $this->assertInstanceOf('Zumba\Util\Test\SupportClasses\AllVisibilities', $obj);
-        $this->assertInstanceOf('Zumba\Util\Test\SupportClasses\EmptyClass', $obj->pub);
+        $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportClasses\AllVisibilities', $obj);
+        $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportClasses\EmptyClass', $obj->pub);
         $this->assertAttributeSame('protected', 'prot', $obj);
         $this->assertAttributeSame('dont tell anyone', 'priv', $obj);
 
-        $serialized = '{"instance":{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\EmptyClass"}}';
+        $serialized = '{"instance":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\EmptyClass"}}';
         $array = $this->serializer->unserialize($serialized);
         $this->assertTrue(is_array($array));
-        $this->assertInstanceOf('Zumba\Util\Test\SupportClasses\EmptyClass', $array['instance']);
+        $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportClasses\EmptyClass', $array['instance']);
     }
 
     /**
@@ -236,7 +236,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
     public function testSerializationMagicMethods()
     {
         $obj = new SupportClasses\MagicClass();
-        $serialized = '{"@type":"Zumba\\\\Util\\\\Test\\\\SupportClasses\\\\MagicClass","show":true}';
+        $serialized = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportClasses\\\\MagicClass","show":true}';
         $this->assertSame($serialized, $this->serializer->serialize($obj));
         $this->assertFalse($obj->woke);
 
@@ -306,7 +306,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
             'nice' => true
         ));
 
-        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->setExpectedException('Zumba\JsonSerializer\Exception\JsonSerializerException');
         $this->serializer->unserialize($serialized);
     }
 
@@ -317,7 +317,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnserializeUnknownClass()
     {
-        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->setExpectedException('Zumba\JsonSerializer\Exception\JsonSerializerException');
         $serialized = '{"@type":"UnknownClass"}';
         $this->serializer->unserialize($serialized);
     }

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -400,4 +400,19 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zumba\Exception\JsonSerializerException');
         $this->serializer->unserialize('[this is not a valid json!}');
     }
+
+    /*
+     * Test namespace change (backward compatibility)
+     *
+     * @return void
+     * @deprecated
+     */
+    public function testNamespaceRename() {
+        $serializer = new \Zumba\Util\JsonSerializer();
+
+        $f = fopen(__FILE__, 'r');
+        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->serializer->serialize($f);
+    }
+
 }

--- a/tests/SupportClasses/AllVisibilities.php
+++ b/tests/SupportClasses/AllVisibilities.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zumba\Util\Test\SupportClasses;
+namespace Zumba\JsonSerializer\Test\SupportClasses;
 
 class AllVisibilities
 {

--- a/tests/SupportClasses/EmptyClass.php
+++ b/tests/SupportClasses/EmptyClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zumba\Util\Test\SupportClasses;
+namespace Zumba\JsonSerializer\Test\SupportClasses;
 
 class EmptyClass
 {

--- a/tests/SupportClasses/MagicClass.php
+++ b/tests/SupportClasses/MagicClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zumba\Util\Test\SupportClasses;
+namespace Zumba\JsonSerializer\Test\SupportClasses;
 
 class MagicClass
 {


### PR DESCRIPTION
Moving the namespace from `Zumba\Util` to a namespace just for the project (`Zumba\JsonSerializer`). I am planning to add more classes, interfaces and traits, which will add things that are not necessarily part of the `Util` namespace.

Also, other open source projects that we have also have dedicated namespaces.

PS: The `JsonSerializer` class is the same, just changing the namespace at the top and the exception namespace. It is just how GitHub shows the file change. On the repo it was a file rename.