### PR TITLE
Throwing exception if cannot decode JSON

### DIFF
--- a/src/Util/JsonSerializer.php
+++ b/src/Util/JsonSerializer.php
@@ -114,7 +114,11 @@ class JsonSerializer
     public function unserialize($value)
     {
         $this->reset();
-        return $this->unserializeData(json_decode($value, true));
+        $data = json_decode($value, true);
+        if ($data === null && json_last_error() != JSON_ERROR_NONE) {
+            throw new JsonSerializerException('Invalid JSON to unserialize.');
+        }
+        return $this->unserializeData($data);
     }
 
     /**

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -389,4 +389,15 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($obj->c2->c3, $obj->c2->c3->c3);
         $this->assertSame($obj->c2->c3_copy, $obj->c2->c3);
     }
+
+    /**
+     * Test unserialize with bad JSON
+     *
+     * @return void
+     */
+    public function testUnserializeBadJSON()
+    {
+        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->serializer->unserialize('[this is not a valid json!}');
+    }
 }


### PR DESCRIPTION
Previously it was silently returning null, which could be interpreted as a good response.