### PR TITLE
Throwing exception if cannot encode JSON when serializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
 vendor
+composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Throwing exception if cannot encode JSON when serializing
 - Throwing exception if cannot decode JSON when unserializing
 ### Deprecated
 - Changed namespace from `Zumba\Util` to `Zumba\JsonSerializer`

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -48,14 +48,14 @@ class JsonSerializer
     /**
      * Closure serializer instance
      *
-     * @var SuperClosure\SerializerInterface
+     * @var ClosureSerializerInterface
      */
     protected $closureSerializer;
 
     /**
      * Constructor.
      *
-     * @param SuperClosure\SerializerInterface $closureSerializer
+     * @param ClosureSerializerInterface $closureSerializer
      */
     public function __construct(ClosureSerializerInterface $closureSerializer = null)
     {
@@ -68,12 +68,15 @@ class JsonSerializer
      *
      * @param mixed $value
      * @return string JSON encoded
-     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
+     * @throws JsonSerializerException
      */
     public function serialize($value)
     {
         $this->reset();
         $encoded = json_encode($this->serializeData($value), $this->calculateEncodeOptions());
+        if ($encoded === false || json_last_error() != JSON_ERROR_NONE) {
+            throw new JsonSerializerException('Invalid data to encode to JSON. Error: ' . json_last_error());
+        }
         return $this->processEncodedValue($encoded);
     }
 
@@ -126,7 +129,7 @@ class JsonSerializer
      *
      * @param mixed $value
      * @return mixed
-     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
+     * @throws JsonSerializerException
      */
     protected function serializeData($value)
     {
@@ -249,9 +252,9 @@ class JsonSerializer
     /**
      * Convert the serialized array into an object
      *
-     * @param aray $value
+     * @param array $value
      * @return object
-     * @throws Zumba\JsonSerializer\Exception\JsonSerializerException
+     * @throws JsonSerializerException
      */
     protected function unserializeObject($value)
     {

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -12,7 +12,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
     /**
      * Serializer instance
      *
-     * @var Zumba\JsonSerializer\JsonSerializer
+     * @var JsonSerializer
      */
     protected $serializer;
 
@@ -32,7 +32,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider scalarData
      * @param mixed $scalar
-     * @param strign $jsoned
+     * @param string $jsoned
      * @return void
      */
     public function testSerializeScalar($scalar, $jsoned)
@@ -64,7 +64,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider scalarData
      * @param mixed $scalar
-     * @param strign $jsoned
+     * @param string $jsoned
      * @return void
      */
     public function testUnserializeScalar($scalar, $jsoned)
@@ -124,7 +124,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider arrayNoObjectData
      * @param array $array
-     * @param strign $jsoned
+     * @param string $jsoned
      * @return void
      */
     public function testSerializeArrayNoObject($array, $jsoned)
@@ -137,7 +137,7 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider arrayNoObjectData
      * @param array $array
-     * @param strign $jsoned
+     * @param string $jsoned
      * @return void
      */
     public function testUnserializeArrayNoObject($array, $jsoned)
@@ -399,6 +399,15 @@ class JsonSerializerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Zumba\Exception\JsonSerializerException');
         $this->serializer->unserialize('[this is not a valid json!}');
+    }
+
+    /**
+     * The test attempts to serialize an array containing a non UTF8 encoded string
+     */
+    public function testSerializeBadData()
+    {
+        $this->setExpectedException('Zumba\Exception\JsonSerializerException');
+        $this->serializer->serialize(array(hex2bin('ba')));
     }
 
     /*


### PR DESCRIPTION
Hiding encoding errors under the rug is dangerous. We use the serializer in a messaging system and we had a hard time finding out why our messages had empty payloads.