### PR TITLE
Add composer test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "keywords": ["json", "serialize", "serializer"],
     "homepage": "http://tech.zumba.com",
     "license": "MIT",
+    "scripts": {
+        "test": "phpunit --colors=always"
+    },
     "authors": [
         {
             "name": "Zumba Fitness, LLC",


### PR DESCRIPTION
Composer gives us the possibility to define scripts in the `composer.json` file: [Documentation on getcomposer.org](https://getcomposer.org/doc/articles/scripts.md)

Most libraries now define a `test` script which makes running unit tests as easy as executing `composer test`.

Here is more on the topic:
- http://maxgfeller.com/blog/2014/07/22/composer-test/
- https://pantheon.io/blog/writing-composer-scripts