### PR TITLE
Fix DateTime serialization in PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "ext-mbstring": "*"
     },
     "suggest": {

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -293,14 +293,18 @@ class JsonSerializer
             $data += $this->customObjectSerializerMap[$className]->serialize($value);
             return $data;
         }
-
-        $paramsToSerialize = $this->getObjectProperties($ref, $value);
+        
         $data = array(static::CLASS_IDENTIFIER_KEY => $className);
+        
+        if ($value instanceof \DateTimeInterface) {
+            return $data + (array) $value;
+        }
 
         if ($value instanceof \SplDoublyLinkedList) {
             return $data + array('value' => $value->serialize());
         }
 
+        $paramsToSerialize = $this->getObjectProperties($ref, $value);
         $data += array_map(array($this, 'serializeData'), $this->extractObjectData($value, $ref, $paramsToSerialize));
         return $data;
     }


### PR DESCRIPTION
In PHP 7.4 calling `get_object_vars(new \DateTime())` returns an empty array, however casting `DateTime` to array still gives the desired effect. This solves #38.