### PR TITLE
Fix #51 (Deprecated with DateTimeImmutable on PHP 8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fixed deprecated with DateTimeImmutable deserialization with PHP 8.2
+
 ## [3.0.0] - 2020-07-20
 ### Fixed
 - Fixed DateTime & DateTimeImmutable serialization in PHP 7.4+. Thanks @przemyslaw-bogusz

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -428,7 +428,7 @@ class JsonSerializer
             throw new JsonSerializerException('Unable to find class ' . $className);
         }
 
-        if ($className === 'DateTime') {
+        if ($className === 'DateTime' || $className === 'DateTimeImmutable') {
             $obj = $this->restoreUsingUnserialize($className, $value);
             $this->objectMapping[$this->objectMappingIndex++] = $obj;
             return $obj;

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -296,6 +296,10 @@ class JsonSerializerTest extends TestCase
         $date = new \DateTime('2014-06-15 12:00:00', new \DateTimeZone('UTC'));
         $obj = $this->serializer->unserialize($this->serializer->serialize($date));
         $this->assertSame($date->getTimestamp(), $obj->getTimestamp());
+
+        $date = new \DateTimeImmutable('2014-06-15 12:00:00', new \DateTimeZone('UTC'));
+        $obj = $this->serializer->unserialize($this->serializer->serialize($date));
+        $this->assertSame($date->getTimestamp(), $obj->getTimestamp());
     }
 
     /**


### PR DESCRIPTION
Hi,

Some little change to avoid a deprecated (issue #51)

> `Creation of dynamic property DateTimeImmutable::$date is deprecated (in JsonSerializer.php on line 463)`

Tell me if I need to rewrite something.

