### PR TITLE
Fix error when unserializing enums

### DIFF
--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -455,7 +455,9 @@ class JsonSerializer
         }
 
         if (is_subclass_of($className, \UnitEnum::class)) {
-            return constant("$className::{$value['name']}");
+            $obj = constant("$className::{$value['name']}");
+            $this->objectMapping[$this->objectMappingIndex++] = $obj;
+            return $obj;
         }
 
         if (!$this->isSplList($className)) {

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -267,6 +267,29 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
+     * Test serialization of multiple Enums
+     *
+     * @return void
+     */
+    public function testSerializeMultipleEnums()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped("Enums are only available since PHP 8.1");
+        }
+
+        $obj = new stdClass();
+        $obj->enum1 = SupportEnums\MyUnitEnum::Hearts;
+        $obj->enum2 = SupportEnums\MyBackedEnum::Hearts;
+        $obj->enum3 = SupportEnums\MyIntBackedEnum::One;
+        $obj->enum4 = SupportEnums\MyUnitEnum::Hearts;
+        $obj->enum5 = SupportEnums\MyBackedEnum::Hearts;
+        $obj->enum6 = SupportEnums\MyIntBackedEnum::One;
+
+        $expected = '{"@type":"stdClass","enum1":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyUnitEnum","name":"Hearts"},"enum2":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyBackedEnum","name":"Hearts","value":"H"},"enum3":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyIntBackedEnum","name":"One","value":1},"enum4":{"@type":"@1"},"enum5":{"@type":"@2"},"enum6":{"@type":"@3"}}';
+        $this->assertSame($expected, $this->serializer->serialize($obj));
+    }
+
+    /**
      * Test unserialization of Enums
      *
      * @return void
@@ -299,6 +322,31 @@ class JsonSerializerTest extends TestCase
         $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportEnums\MyBackedEnum', $obj);
         $this->assertSame(SupportEnums\MyBackedEnum::Hearts, $obj);
         $this->assertSame(SupportEnums\MyBackedEnum::Hearts->value, $obj->value);
+    }
+
+    /**
+     * Test unserialization of multiple Enums
+     *
+     * @return void
+     */
+    public function testUnserializeMultipleEnums()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped("Enums are only available since PHP 8.1");
+        }
+
+        $obj = new stdClass();
+        $obj->enum1 = SupportEnums\MyUnitEnum::Hearts;
+        $obj->enum2 = SupportEnums\MyBackedEnum::Hearts;
+        $obj->enum3 = SupportEnums\MyIntBackedEnum::One;
+        $obj->enum4 = SupportEnums\MyUnitEnum::Hearts;
+        $obj->enum5 = SupportEnums\MyBackedEnum::Hearts;
+        $obj->enum6 = SupportEnums\MyIntBackedEnum::One;
+
+        $serialized = '{"@type":"stdClass","enum1":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyUnitEnum","name":"Hearts"},"enum2":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyBackedEnum","name":"Hearts","value":"H"},"enum3":{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyIntBackedEnum","name":"One","value":1},"enum4":{"@type":"@1"},"enum5":{"@type":"@2"},"enum6":{"@type":"@3"}}';
+        $actualObj = $this->serializer->unserialize($serialized);
+        $this->assertInstanceOf('stdClass', $actualObj);
+        $this->assertEquals($obj, $actualObj);
     }
 
     /**

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -260,6 +260,10 @@ class JsonSerializerTest extends TestCase
         $backedEnum = SupportEnums\MyBackedEnum::Hearts;
         $expected = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyBackedEnum","name":"Hearts","value":"H"}';
         $this->assertSame($expected, $this->serializer->serialize($backedEnum));
+
+        $intBackedEnum = SupportEnums\MyIntBackedEnum::One;
+        $expected = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyIntBackedEnum","name":"One","value":1}';
+        $this->assertSame($expected, $this->serializer->serialize($intBackedEnum));
     }
 
     /**
@@ -282,6 +286,12 @@ class JsonSerializerTest extends TestCase
         $obj = $this->serializer->unserialize($serialized);
         $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportEnums\MyBackedEnum', $obj);
         $this->assertSame(SupportEnums\MyBackedEnum::Hearts, $obj);
+
+        $serialized = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyIntBackedEnum","name":"Two","value":2}';
+        $obj = $this->serializer->unserialize($serialized);
+        $this->assertInstanceOf('Zumba\JsonSerializer\Test\SupportEnums\MyIntBackedEnum', $obj);
+        $this->assertSame(SupportEnums\MyIntBackedEnum::Two, $obj);
+        $this->assertSame(SupportEnums\MyIntBackedEnum::Two->value, $obj->value);
 
         // wrong value of BackedEnum is ignored
         $serialized = '{"@type":"Zumba\\\\JsonSerializer\\\\Test\\\\SupportEnums\\\\MyBackedEnum","name":"Hearts","value":"S"}';

--- a/tests/SupportEnums/MyIntBackedEnum.php
+++ b/tests/SupportEnums/MyIntBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Zumba\JsonSerializer\Test\SupportEnums;
+
+enum MyIntBackedEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}


### PR DESCRIPTION
Unserialized enums are not saved in the `objectMapping` property.
Also adds tests for int backed enums.