### PR TITLE
Remove tests from the vendor bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.github export-ignore
-
+/tests export-ignore
+/phpunit.xml export-ignore

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Serialize PHP variables, including objects, in JSON format. Support to unserialize it too.",
     "keywords": ["json", "serialize", "serializer"],
-    "homepage": "http://tech.zumba.com",
+    "homepage": "https://tech.zumba.com",
     "license": "MIT",
     "scripts": {
         "test": "phpunit --colors=always"
@@ -33,11 +33,5 @@
             "Zumba\\": "src/",
             "Zumba\\JsonSerializer\\Test\\": "tests/"
         }
-    },
-    "archive": {
-        "exclude": [
-            "/tests",
-            "/phpunit.xml"
-        ]
     }
 }


### PR DESCRIPTION
In Debian packaging I have another way of having them back by doing a git clone.
They can be removed from the vendor bundle.

By the way: could you be the one to publish signed git tags and not GitHub ?
You already have a GPG key, if you can guarantee that all following releases will be git tag signed by your GPG key I can add this as a packaging safety.

Ref: https://manpages.debian.org/testing/devscripts/uscan.1.en.html#pgpmode=

`pgpmode=gittag`

And importing your public GPG key in `debian/upstream/signing-key.asc`
Ref: https://wiki.debian.org/debian/upstream