### PR TITLE
Keep BC compat to PHP 7: Don't use "::class" on dynamic class names

### DIFF
--- a/src/JsonSerializer/ClosureSerializer/ClosureSerializerManager.php
+++ b/src/JsonSerializer/ClosureSerializer/ClosureSerializerManager.php
@@ -27,7 +27,8 @@ class ClosureSerializerManager {
      */
     public function addSerializer(ClosureSerializer $closureSerializer)
     {
-        $classname = $closureSerializer::class;
+        // Keep BC compat to PHP 7: Don't use "::class" on dynamic class names
+        $classname = get_class($closureSerializer);
         $this->closureSerializer[$classname] = $closureSerializer;
         return $this;
     }

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -264,7 +264,8 @@ class JsonSerializer
             }
             return [
                 static::CLOSURE_IDENTIFIER_KEY => true,
-                'serializer' => $closureSerializer::class,
+                // Keep BC compat to PHP 7: Don't use "::class" on dynamic class names
+                'serializer' => get_class($closureSerializer),
                 'value' => $closureSerializer->serialize($value)
             ];
         }


### PR DESCRIPTION
Fix #58