### PR TITLE
Improvements and fixes

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-version }}
     steps:
     - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
       run: composer validate
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Limitations:
 This project should not be confused with `JsonSerializable` interface added on PHP 5.4. This interface is used on
 `json_encode` to encode the objects. There is no unserialization with this interface, differently from this project.
 
-*Json Serializer requires PHP >= 7.0 and tested until PHP 8.2*
+*Json Serializer requires PHP >= 7.2 and tested until PHP 8.2*
 
 ## Example
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "opis/closure": "Allow to serialize PHP closures"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.0 <11.0"
+        "phpunit/phpunit": ">=8 <12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-mbstring": "*"
     },
     "suggest": {

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -72,11 +72,11 @@ class JsonSerializer
     /**
      * Constructor.
      *
-     * @param ClosureSerializerInterface $closureSerializer This parameter is deprecated and will be removed in 5.0.0. Use addClosureSerializer() instead.
+     * @param ClosureSerializerInterface|null $closureSerializer This parameter is deprecated and will be removed in 5.0.0. Use addClosureSerializer() instead.
      * @param array                      $customObjectSerializerMap
      */
     public function __construct(
-        ClosureSerializerInterface $closureSerializer = null,
+        ?ClosureSerializerInterface $closureSerializer = null,
         $customObjectSerializerMap = []
     ) {
         $this->closureManager = new ClosureSerializer\ClosureSerializerManager();

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -26,6 +26,7 @@ class JsonSerializerTest extends TestCase
      * @before
      * @return void
      */
+    #[\PHPUnit\Framework\Attributes\Before]
     public function setUpSerializer()
     {
         $customObjectSerializerMap['Zumba\\JsonSerializer\\Test\\SupportClasses\\MyType'] = new \Zumba\JsonSerializer\Test\SupportClasses\MyTypeSerializer();
@@ -40,6 +41,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('scalarData')]
     public function testSerializeScalar($scalar, $jsoned)
     {
         $this->assertSame($jsoned, $this->serializer->serialize($scalar));
@@ -74,6 +76,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('scalarData')]
     public function testUnserializeScalar($scalar, $jsoned)
     {
         $this->assertSame($scalar, $this->serializer->unserialize($jsoned));
@@ -134,6 +137,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('arrayNoObjectData')]
     public function testSerializeArrayNoObject($array, $jsoned)
     {
         $this->assertSame($jsoned, $this->serializer->serialize($array));
@@ -147,6 +151,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('arrayNoObjectData')]
     public function testUnserializeArrayNoObject($array, $jsoned)
     {
         $this->assertSame($array, $this->serializer->unserialize($jsoned));


### PR DESCRIPTION
Fixes #61

Drop PHP 7.0, 7.1.  This can be released in a minor version

Upgrades and non breaking changes for newer PHPUnit versions